### PR TITLE
fix(event card component): fixed hover over components and translatio…

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -145,7 +145,12 @@
         "eventCards": {
             "attendees": "Attendees",
             "join": "JOIN",
-            "leave": "LEAVE"
+            "leave": "LEAVE",
+            "toJoinTurkish": "",
+            "or": " OR ",
+            "signIn": "Sign In",
+            "signUp": "Sign Up",
+            "toJoinEnglish": "to join events."
         }
     },
     "eventViewPage": {

--- a/public/locales/tr/common.json
+++ b/public/locales/tr/common.json
@@ -146,7 +146,12 @@
         "eventCards": {
             "attendees": "Katılımcı",
             "join": "KATIL",
-            "leave": "AYRIL"
+            "leave": "AYRIL",
+            "toJoinTurkish": "Etkinliklere katılmak için ",
+            "or": " yada ",
+            "signIn": "giriş yap",
+            "signUp": "kayıt ol",
+            "toJoinEnglish": ""
         }
     },
     "eventViewPage": {

--- a/src/components/EventCards/EventCards.jsx
+++ b/src/components/EventCards/EventCards.jsx
@@ -26,10 +26,10 @@ const EventCards = ({ events = [], isJoined = {}, handleJoinClick }) => {
     return (
         <div>
             {events.map((event) => (
-                <Link href={`/${event._id}`} key={event._id}>
+                <Link className='' href={`/${event._id}`} key={event._id}>
                     <div
                         key={event._id}
-                        className='mx-6 mb-4 rounded-md border shadow-lg sm:mx-4'
+                        className='mx-6 mb-4 rounded-md border shadow-lg hover:cursor-pointer sm:mx-4'
                     >
                         <div className='mx-4 mt-4 flex flex-col text-center sm:flex-row sm:justify-between'>
                             <h2 className='mb-2 sm:mb-0'>{event.date}</h2>
@@ -87,22 +87,32 @@ const EventCards = ({ events = [], isJoined = {}, handleJoinClick }) => {
                                     )}
                                     {/* if user is NOT signed in show sign in or sign up buttons */}
                                     {!auth?.email && (
-                                        <div className='text-blue flex flex-row items-center '>
-                                            <Link
-                                                className='hover:pointer'
-                                                href='/signin'
-                                            >
-                                                <p className='text-primary-200 underline'>
-                                                    {t("common.nav.signIn")}
+                                        <div className='text-blue m-2 flex flex-row flex-wrap items-center hover:cursor-default'>
+                                            {t(
+                                                "eventsPage.eventCards.toJoinTurkish"
+                                            )}
+                                            &nbsp;
+                                            <Link className='' href='/signin'>
+                                                <p className='text-primary-200 underline hover:cursor-pointer'>
+                                                    {t(
+                                                        "eventsPage.eventCards.signIn"
+                                                    )}
                                                 </p>
                                             </Link>
-                                            &nbsp;OR&nbsp;
+                                            &nbsp;
+                                            {t("eventsPage.eventCards.or")}
+                                            &nbsp;
                                             <Link href='/signup'>
-                                                <p className='text-primary-200 underline'>
-                                                    {t("common.nav.signUp")}
+                                                <p className='text-primary-200 underline hover:cursor-pointer'>
+                                                    {t(
+                                                        "eventsPage.eventCards.signUp"
+                                                    )}
                                                 </p>
                                             </Link>
-                                            &nbsp;to join events.
+                                            &nbsp;
+                                            {t(
+                                                "eventsPage.eventCards.toJoinEnglish"
+                                            )}
                                         </div>
                                     )}
                                 </div>

--- a/src/pages/[eventId].jsx
+++ b/src/pages/[eventId].jsx
@@ -61,6 +61,12 @@ export default function EventViewPage({ event }) {
                 : event.confirmedVolunteers[i].profileImage
         );
     }
+    let hostProfileURL = event.publisherId
+        ? event.publisherId.profileImage
+        : "/images/userAvatar.jpeg";
+    if (hostProfileURL === undefined) {
+        hostProfileURL = "/images/userAvatar.jpeg";
+    }
     return (
         <Layout>
             <EventBanner
@@ -73,11 +79,7 @@ export default function EventViewPage({ event }) {
                 attendees={volunteers}
                 attendeeProfileURLs={volunteerProfileURLs}
                 host={event.publisherId ? event.publisherId.firstName : "N/A"}
-                hostProfileURL={
-                    event.publisherId
-                        ? event.publisherId.profileImage
-                        : "/images/userAvatar.jpeg"
-                }
+                hostProfileURL={hostProfileURL}
             />
             <EventDescriptionAttendeesList
                 description={event.content}


### PR DESCRIPTION
This PR fixes a few issues:
1. The newly created events were giving an SRC error. Fixed them! Now you can click on an event card and it takes you to the event view page:
![image](https://user-images.githubusercontent.com/17632992/186899228-3338ba03-4262-4cda-94e9-d8667f8a1647.png)

2. Hovering over components now gives a pointer cursor, and same with Sign In or Sign Up to join events text. (Only over the Sign In and Sign Up links.
![image](https://user-images.githubusercontent.com/17632992/186899337-4987a398-cf69-44f4-b91d-55c4e2180d53.png)

3. Translated Sign In or Sign Up to join events:
![image](https://user-images.githubusercontent.com/17632992/186899294-27430c0b-af3c-444a-b4f2-c90b4e398c67.png)

closes #118 closes #120


# Related Issue

- Resolve #118