### PR TITLE
feat: added reset filters button-i18next translations-styling fix

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -112,12 +112,13 @@
         "description": "Explore and Join Events.",
         "calendarComp": {
             "changeDate": "Change Date",
-            "submit": "SUBMIT"
+            "submit": "Change Date"
         },
         "locationComp": {
             "changeLocation": "Change Location",
-            "searchLocation": "Search Location",
-            "search": "SEARCH"
+            "searchLocation": "Type a Location...",
+            "searchEventLocation": "Search Event Location",
+            "search": "Search Location"
         },
         "categoryCheckboxes": {
             "chooseCategory": "Choose Category",
@@ -154,7 +155,14 @@
             "signIn": "Sign In",
             "signUp": "Sign Up",
             "toJoinEnglish": "to join events."
-        }
+        },
+        "resetFilters": "Reset Filters",
+        "toast": {
+            "noCategory": "Please select at least one category",
+            "noLocation": "Please select a city.",
+            "noFilters": "No filters to reset"
+        },
+        "noEvents": "No events found according to applied filters"
     },
     "eventViewPage": {
         "eventBanner": {

--- a/public/locales/tr/common.json
+++ b/public/locales/tr/common.json
@@ -113,12 +113,13 @@
         "description": "Keşfet ve Etkinliklere Katıl.",
         "calendarComp": {
             "changeDate": "Tarih Değiştir",
-            "submit": "GÖNDER"
+            "submit": "Tarihi Değiştir"
         },
         "locationComp": {
             "changeLocation": "Konum Değiştir",
-            "searchLocation": "Konum Ara",
-            "search": "ARA"
+            "searchLocation": "Bir Konum İsmi Girin...",
+            "searchEventLocation": "Bir Konum Arayın",
+            "search": "Konum Ara"
         },
         "categoryCheckboxes": {
             "chooseCategory": "Kategori Seç",
@@ -155,7 +156,14 @@
             "signIn": "giriş yap",
             "signUp": "kayıt ol",
             "toJoinEnglish": ""
-        }
+        },
+        "resetFilters": "Filtreleri Sıfırla",
+        "toast": {
+            "noCategory": "Lütfen en az bir kategori seçin.",
+            "noLocation": "Lütfen bir şehir seçin.",
+            "noFilters": "Sıfırlanacak bir filtre uygulanmadı"
+        },
+        "noEvents": "Uygulanan filtrelere göre etkinlik bulunamadı"
     },
     "eventViewPage": {
         "eventBanner": {

--- a/src/components/CalendarComp/CalendarComp.jsx
+++ b/src/components/CalendarComp/CalendarComp.jsx
@@ -20,7 +20,7 @@ const CalendarComp = ({ style, setRange, range, handleDateSubmit }) => {
                             moveRangeOnFirstSelection={false}
                             ranges={range}
                             months={1}
-                            fixedHeight={false}
+                            fixedHeight={true}
                             rangeColors={["#0180AB", "#BDD6D0"]}
                             direction='vertical'
                             className='calendarElement mb-2 border-2'
@@ -28,12 +28,7 @@ const CalendarComp = ({ style, setRange, range, handleDateSubmit }) => {
                         <Button
                             type='submit'
                             label={t("eventsPage.calendarComp.submit")}
-                            textColor='text-white'
-                            bgColor='bg-primary-200'
-                            borderColor='border-primary-200'
-                            height='h-10'
-                            widht='w-32'
-                            customStyle='text-base rounded'
+                            customStyle='text-base rounded-md bg-secondary-300 border-secondary-300 border-2 text-white mt-0 mb-0 py-0 px-0 bg-white shadow-sm w-48'
                             onClick={handleDateSubmit}
                         />
                     </div>

--- a/src/components/CalendarComp/__test__/__snapshots__/CalendarComp.test.jsx.snap
+++ b/src/components/CalendarComp/__test__/__snapshots__/CalendarComp.test.jsx.snap
@@ -1453,7 +1453,7 @@ exports[`renders correctly 1`] = `
                   </span>
                 </button>
                 <button
-                  className="rdrDay rdrDayToday"
+                  className="rdrDay"
                   onBlur={[Function]}
                   onFocus={[Function]}
                   onKeyDown={[Function]}
@@ -1479,7 +1479,7 @@ exports[`renders correctly 1`] = `
                   </span>
                 </button>
                 <button
-                  className="rdrDay rdrDayWeekend rdrDayEndOfWeek"
+                  className="rdrDay rdrDayToday rdrDayWeekend rdrDayEndOfWeek"
                   onBlur={[Function]}
                   onFocus={[Function]}
                   onKeyDown={[Function]}
@@ -1689,12 +1689,201 @@ exports[`renders correctly 1`] = `
                     </span>
                   </span>
                 </button>
+                <button
+                  className="rdrDay rdrDayPassive rdrDayWeekend rdrDayStartOfWeek"
+                  onBlur={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseUp={[Function]}
+                  onPauseCapture={[Function]}
+                  style={
+                    Object {
+                      "color": "#3d91ff",
+                    }
+                  }
+                  tabIndex={-1}
+                  type="button"
+                >
+                  <span
+                    className="rdrDayNumber"
+                  >
+                    <span>
+                      4
+                    </span>
+                  </span>
+                </button>
+                <button
+                  className="rdrDay rdrDayPassive"
+                  onBlur={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseUp={[Function]}
+                  onPauseCapture={[Function]}
+                  style={
+                    Object {
+                      "color": "#3d91ff",
+                    }
+                  }
+                  tabIndex={-1}
+                  type="button"
+                >
+                  <span
+                    className="rdrDayNumber"
+                  >
+                    <span>
+                      5
+                    </span>
+                  </span>
+                </button>
+                <button
+                  className="rdrDay rdrDayPassive"
+                  onBlur={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseUp={[Function]}
+                  onPauseCapture={[Function]}
+                  style={
+                    Object {
+                      "color": "#3d91ff",
+                    }
+                  }
+                  tabIndex={-1}
+                  type="button"
+                >
+                  <span
+                    className="rdrDayNumber"
+                  >
+                    <span>
+                      6
+                    </span>
+                  </span>
+                </button>
+                <button
+                  className="rdrDay rdrDayPassive"
+                  onBlur={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseUp={[Function]}
+                  onPauseCapture={[Function]}
+                  style={
+                    Object {
+                      "color": "#3d91ff",
+                    }
+                  }
+                  tabIndex={-1}
+                  type="button"
+                >
+                  <span
+                    className="rdrDayNumber"
+                  >
+                    <span>
+                      7
+                    </span>
+                  </span>
+                </button>
+                <button
+                  className="rdrDay rdrDayPassive"
+                  onBlur={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseUp={[Function]}
+                  onPauseCapture={[Function]}
+                  style={
+                    Object {
+                      "color": "#3d91ff",
+                    }
+                  }
+                  tabIndex={-1}
+                  type="button"
+                >
+                  <span
+                    className="rdrDayNumber"
+                  >
+                    <span>
+                      8
+                    </span>
+                  </span>
+                </button>
+                <button
+                  className="rdrDay rdrDayPassive"
+                  onBlur={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseUp={[Function]}
+                  onPauseCapture={[Function]}
+                  style={
+                    Object {
+                      "color": "#3d91ff",
+                    }
+                  }
+                  tabIndex={-1}
+                  type="button"
+                >
+                  <span
+                    className="rdrDayNumber"
+                  >
+                    <span>
+                      9
+                    </span>
+                  </span>
+                </button>
+                <button
+                  className="rdrDay rdrDayPassive rdrDayWeekend rdrDayEndOfWeek"
+                  onBlur={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseUp={[Function]}
+                  onPauseCapture={[Function]}
+                  style={
+                    Object {
+                      "color": "#3d91ff",
+                    }
+                  }
+                  tabIndex={-1}
+                  type="button"
+                >
+                  <span
+                    className="rdrDayNumber"
+                  >
+                    <span>
+                      10
+                    </span>
+                  </span>
+                </button>
               </div>
             </div>
           </div>
         </div>
         <button
-          className="mt-1 mb-1 w-30 h-10 undefined bg-primary-200 undefined undefined hover:undefined text-white font-normal  py-1  px-2 border-primary-200 hover:undefined rounded  hover:shadow-lg text-base rounded"
+          className="mt-1 mb-1 w-30 h-8 undefined bg-secondary-300 undefined undefined hover:undefined text-white font-normal  py-1  px-2 undefined hover:undefined rounded  hover:shadow-lg text-base rounded-md bg-secondary-300 border-secondary-300 border-2 text-white mt-0 mb-0 py-0 px-0 bg-white shadow-sm w-48"
           onClick={[Function]}
           type="submit"
         >

--- a/src/components/EventCards/EventCards.jsx
+++ b/src/components/EventCards/EventCards.jsx
@@ -123,7 +123,7 @@ const EventCards = ({ events = [], isJoined = {}, handleJoinClick }) => {
                                     )}
                                     {/* if user is NOT signed in show sign in or sign up buttons */}
                                     {!auth?.email && (
-                                        <div className='text-blue m-2 flex flex-row flex-wrap items-center hover:cursor-default'>
+                                        <div className='text-blue m-2 flex flex-row flex-wrap justify-center hover:cursor-default'>
                                             {t(
                                                 "eventsPage.eventCards.toJoinTurkish"
                                             )}

--- a/src/components/LocationComp/LocationComp.jsx
+++ b/src/components/LocationComp/LocationComp.jsx
@@ -98,7 +98,7 @@ const LocationComp = ({
             <div className='sm:relative sm:w-full sm:border-none sm:bg-transparent sm:shadow-none'>
                 <div className='flex flex-col items-center md:flex-row '>
                     <h1 className='mb-2 text-center text-xl font-bold sm:hidden'>
-                        Search Event Location
+                        {t("eventsPage.locationComp.searchEventLocation")}
                     </h1>
                     <InputComponent
                         type='text'
@@ -108,16 +108,10 @@ const LocationComp = ({
                         )}
                         value={searchTerm}
                         callback={handleSearch}
-                        className='mb-2 h-1/2 w-3/4 rounded-md text-base focus:border-secondary-300 sm:mb-0 sm:w-full'
-                    />
-                    <Button
-                        onClick={() => onSearch(searchTerm)}
-                        label={t("eventsPage.locationComp.search")}
-                        height='h-9'
-                        customStyle='text-base bg-primary-200 border rounded text-white ml-2'
+                        className='mb-2 h-9 w-3/4 rounded-md border-gray-200 text-base placeholder-black focus:border-secondary-300 sm:mb-0 sm:w-full'
                     />
                 </div>
-                <div>
+                <div className='mt-2 flex flex-col items-center'>
                     {citiesOfTurkey
                         .filter((city) => {
                             const searchCity = searchTerm.toLowerCase();
@@ -140,6 +134,11 @@ const LocationComp = ({
                                 {city}
                             </div>
                         ))}
+                    <Button
+                        onClick={() => onSearch(searchTerm)}
+                        label={t("eventsPage.locationComp.search")}
+                        customStyle='rounded-md border-2 mb-0 py-0 px-0 bg-white text-black shadow-sm w-48'
+                    />
                 </div>
             </div>
         </div>

--- a/src/components/LocationComp/__test__/__snapshots__/LocationComp.test.jsx.snap
+++ b/src/components/LocationComp/__test__/__snapshots__/LocationComp.test.jsx.snap
@@ -13,25 +13,28 @@ exports[`renders correctly 1`] = `
       <h1
         className="mb-2 text-center text-xl font-bold sm:hidden"
       >
-        Search Event Location
+        eventsPage.locationComp.searchEventLocation
       </h1>
       <input
-        className="mb-2 h-1/2 w-3/4 rounded-md text-base focus:border-secondary-300 sm:mb-0 sm:w-full"
+        className="mb-2 h-9 w-3/4 rounded-md border-gray-200 text-base placeholder-black focus:border-secondary-300 sm:mb-0 sm:w-full"
         id="cities"
         placeholder="eventsPage.locationComp.searchLocation"
         type="text"
         value=""
       />
       <label />
+    </div>
+    <div
+      className="mt-2 flex flex-col items-center"
+    >
       <button
-        className="mt-1 mb-1 w-30 h-9 undefined bg-secondary-300 undefined undefined hover:undefined text-white font-normal  py-1  px-2 undefined hover:undefined rounded  hover:shadow-lg text-base bg-primary-200 border rounded text-white ml-2"
+        className="mt-1 mb-1 w-30 h-8 undefined bg-secondary-300 undefined undefined hover:undefined text-white font-normal  py-1  px-2 undefined hover:undefined rounded  hover:shadow-lg rounded-md border-2 mb-0 py-0 px-0 bg-white text-black shadow-sm w-48"
         onClick={[Function]}
         type="button"
       >
         eventsPage.locationComp.search
       </button>
     </div>
-    <div />
   </div>
 </div>
 `;

--- a/src/pages/events.jsx
+++ b/src/pages/events.jsx
@@ -4,6 +4,7 @@ import { useRouter } from "next/router";
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import { useEffect, useRef, useState } from "react";
+import toast from "react-hot-toast";
 
 import useAuth from "@/hooks/useAuth";
 
@@ -281,7 +282,10 @@ const EventsPage = ({ events }) => {
     let categoryFilterURL = "";
     function handleApplyFilters() {
         //construct URL to render events based on category filters
-        if (checkedBoxes.length > 0) {
+        setIsInterestButtonClicked(!isInterestButtonClicked);
+        if (checkedBoxes.length === 0) {
+            toast(t("eventsPage.toast.noCategory"));
+        } else if (checkedBoxes.length > 0) {
             categoryFilterURL =
                 "?" + "categories=" + checkedBoxes.join("&categories=");
 
@@ -327,12 +331,15 @@ const EventsPage = ({ events }) => {
     let cityFilterURL = "";
     function onSearch(selectedCity) {
         //construct URL to render events based on city filters
+        setIsLocationButtonClicked(!isLocationButtonClicked);
         setSearchTerm(selectedCity);
         cityFilterURL = "?" + "city=" + selectedCity;
         let cityURL = `&city=${selectedCity}`;
 
         setParams({ ...params, city: selectedCity });
-        if (
+        if (selectedCity === "") {
+            toast(t("eventsPage.toast.noLocation"));
+        } else if (
             params.categories.length == 0 &&
             params.dateFilter.fromDate == "" &&
             params.dateFilter.toDate == ""
@@ -382,6 +389,7 @@ const EventsPage = ({ events }) => {
     let dateFilterURL = "";
     function handleDateSubmit() {
         //construct URL to render events based on date filters - for Mobile
+        setIsDateButtonClicked(!isDateButtonClicked);
         let fromDate = format(range[0].startDate, "yyyy-MM-dd");
         let toDate = format(range[0].endDate, "yyyy-MM-dd");
         dateFilterURL = "?" + "fromDate=" + fromDate + "&toDate=" + toDate;
@@ -510,6 +518,38 @@ const EventsPage = ({ events }) => {
         // API Call to join event
     }
 
+    //reset filters
+    function handleResetFilters() {
+        if (
+            params.categories.length == 0 &&
+            params.city == "" &&
+            params.dateFilter.fromDate == "" &&
+            params.dateFilter.toDate == ""
+        ) {
+            toast(t("eventsPage.toast.noFilters"));
+        } else if (
+            router.query.categories !== undefined ||
+            router.query.city !== undefined ||
+            router.query.fromDate !== undefined ||
+            router.query.toDate !== undefined
+        ) {
+            setParams({
+                categories: [],
+                city: "",
+                dateFilter: { fromDate: "", toDate: "" },
+            });
+            setRange([
+                {
+                    ...range,
+                    startDate: new Date(),
+                    endDate: addDays(new Date(), 0),
+                },
+            ]);
+            setSearchTerm("");
+            router.push(router.pathname);
+        }
+    }
+
     return (
         <Layout>
             <div className='flex justify-center text-center sm:mx-12 sm:grid sm:grid-cols-3  sm:text-start'>
@@ -617,6 +657,15 @@ const EventsPage = ({ events }) => {
                             />
                         </div>
                     ) : null}
+                    <div className='mx-3 mt-4 flex flex-col items-center sm:mx-4 sm:mt-0'>
+                        <hr className='my-4 mx-3 hidden w-full sm:block' />
+                        <Button
+                            label={t("eventsPage.resetFilters")}
+                            onClick={handleResetFilters}
+                            bgColor='bg-primary-200'
+                            customStyle='rounded-md border-2 mt-0 mb-0 py-0 px-0 bg-white text-black shadow-sm w-48'
+                        />
+                    </div>
                 </div>
                 <hr className='my-4 mx-3 text-black sm:hidden' />
 
@@ -630,7 +679,7 @@ const EventsPage = ({ events }) => {
                     ) : (
                         <div className='flex justify-center text-center'>
                             <p className='mt-2 text-xl font-bold'>
-                                No events found according to applied filters
+                                {t("eventsPage.noEvents")}
                             </p>
                         </div>
                     )}

--- a/src/styles/calendarStyle.css
+++ b/src/styles/calendarStyle.css
@@ -12,6 +12,6 @@
 }
 @media screen and (min-width: 640px) and (max-width: 1024px) {
     .calendarWrap {
-        height: 20rem !important;
+        height: 22rem !important;
     }
 }


### PR DESCRIPTION
- added a "**reset filters**" button
- changed eventsPage component buttons ( styled them to have the same bg color and width/height)

desktop

![reset_desktop](https://user-images.githubusercontent.com/100930519/187043190-e77d3c1a-4a0e-42ee-a3e6-6938bc92701d.png)


mobile
![0](https://user-images.githubusercontent.com/100930519/187043196-629e3050-c134-4c07-9c34-b5fd31d22737.png)

- Added i18Next translations where necessary
- Used react hot toast to notify user, in case they click filter button without selecting any location or category interest
- Made the filter components (calendar, location, categories) unmount when their submit buttons clicked.
- Re-styled calendar component. Now it has fixed height.






# Related Issue

- Resolve #126