### PR TITLE
feat: filtered events: only future events are rendered

### DIFF
--- a/src/components/CalendarComp/__test__/__snapshots__/CalendarComp.test.jsx.snap
+++ b/src/components/CalendarComp/__test__/__snapshots__/CalendarComp.test.jsx.snap
@@ -1453,7 +1453,7 @@ exports[`renders correctly 1`] = `
                   </span>
                 </button>
                 <button
-                  className="rdrDay rdrDayToday"
+                  className="rdrDay"
                   onBlur={[Function]}
                   onFocus={[Function]}
                   onKeyDown={[Function]}
@@ -1479,7 +1479,7 @@ exports[`renders correctly 1`] = `
                   </span>
                 </button>
                 <button
-                  className="rdrDay rdrDayWeekend rdrDayEndOfWeek"
+                  className="rdrDay rdrDayToday rdrDayWeekend rdrDayEndOfWeek"
                   onBlur={[Function]}
                   onFocus={[Function]}
                   onKeyDown={[Function]}

--- a/src/pages/events.jsx
+++ b/src/pages/events.jsx
@@ -146,14 +146,6 @@ export async function getServerSideProps({ locale, query }) {
 }
 
 const EventsPage = ({ events }) => {
-    const [currentPage, setCurrentPage] = useState(1);
-    const [postsPerPage] = useState(10);
-
-    const indexOfLastPost = currentPage * postsPerPage;
-    const indexOfFirstPost = indexOfLastPost - postsPerPage;
-    const currentPosts = events.slice(indexOfFirstPost, indexOfLastPost);
-    const paginate = (pageNumber) => setCurrentPage(pageNumber);
-
     const { t } = useTranslation("common");
     const { auth } = useAuth();
     const router = useRouter();
@@ -271,6 +263,24 @@ const EventsPage = ({ events }) => {
     }
 
     //FILTERING EVENTS
+    let today = new Date();
+    let formattedToday = format(today, "yyyy-MM-dd");
+
+    const futureEvents = [];
+    events.map((e) => {
+        if (e.date.split("T")[0] >= formattedToday) {
+            futureEvents.push(e);
+        }
+    });
+
+    const [currentPage, setCurrentPage] = useState(1);
+    const [postsPerPage] = useState(10);
+
+    const indexOfLastPost = currentPage * postsPerPage;
+    const indexOfFirstPost = indexOfLastPost - postsPerPage;
+    const currentPosts = futureEvents.slice(indexOfFirstPost, indexOfLastPost);
+    const paginate = (pageNumber) => setCurrentPage(pageNumber);
+
     const [params, setParams] = useState({
         categories: [],
         city: "",


### PR DESCRIPTION
Filtered events to show users only future events.
Past events are unaccesible now...

# Related Issue

- Resolve #128